### PR TITLE
fix(slick): fixing calculation regarding canvas height [SO-1993006]

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3083,10 +3083,13 @@
         var numberOfRows = dataLengthIncludingAddNew + (options.leaveSpaceForNewRows ? numVisibleRows - 1 : 0);
       }
 
+      const totalRowsHeight = data.map(row => row._rowHeight || options.rowHeight)
+        .reduce((total, height) => total + height, 0);
+
       var tempViewportH = $viewportScrollContainerY.height();
       var oldViewportHasVScroll = viewportHasVScroll;
       // with autoHeight, we do not need to accommodate the vertical scroll bar
-      viewportHasVScroll = (!options.autoHeight && options.hasScrollBar) && (numberOfRows * options.rowHeight > tempViewportH);
+      viewportHasVScroll = (!options.autoHeight && options.hasScrollBar) && (totalRowsHeight > tempViewportH);
 
       makeActiveCellNormal();
 
@@ -3098,9 +3101,6 @@
           removeRowFromCache(i);
         }
       }
-
-      const totalRowsHeight = data.map(row => row._rowHeight || options.rowHeight)
-        .reduce((total, height) => total + height, 0);
 
       th = Math.max(totalRowsHeight, tempViewportH - scrollbarDimensions.height);
 


### PR DESCRIPTION
**What has been done**
The calculation to flag if there is a vertical scroll bar was not considering custom row heights. This flag was being used to calculate the width of the columns and, in certain situations, was 12px off because of that wrong calculation.

**Attention**
After merging this PR, a release must be executed and it's version replaced on tasy-framework's package.json.