### PR TITLE
Fix for multiple rows selection using 'Shift' and arrow keys on grids…

### DIFF
--- a/plugins/slick.rowselectionmodel.js
+++ b/plugins/slick.rowselectionmodel.js
@@ -104,6 +104,10 @@
     }
 
     function handleKeyDown(e) {
+      if (!_grid.getOptions().multiSelect) {
+        return false;
+      }
+
       var activeRow = _grid.getActiveCell();
       if (activeRow && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey && (e.which == 38 || e.which == 40)) {
         var selectedRows = getSelectedRows();


### PR DESCRIPTION
Fix for multiple rows selection using 'Shift' and arrow keys on grids without 'multiSelect'. 
SO-2273298 - Unexpected behavior when using multiple WDBP  