### PR TITLE
OS-2373285 - Fixed bug of invisible scrollbar

### DIFF
--- a/slick.grid.css
+++ b/slick.grid.css
@@ -216,7 +216,7 @@ classes should alter those!
   width: 100%;
 }
 
-div.slick-viewport.slick-viewport-top.slick-viewport-left::-webkit-scrollbar:vertical {
+.no-vertical-scrollbar::-webkit-scrollbar:vertical {
   width: 0;
   background: transparent;
 }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3498,6 +3498,12 @@
       // remove rows no longer in the viewport
       cleanupRows(rendered);
 
+      if (hasFrozenColumns()) {
+        $viewportTopL.addClass('no-vertical-scrollbar');
+      } else {
+        $viewportTopL.removeClass('no-vertical-scrollbar');
+      }
+
       // add new rows & missing cells in existing rows
       if (lastRenderedScrollLeft != scrollLeft) {
 


### PR DESCRIPTION
Fixed bug created by the [PR 45](https://github.com/philips-emr/X-SlickGrid/pull/45) in which the top left viewport had an invisible scrollbar.
Now the viewport have a invisible scrollbar only when there are frozen columns.