### PR TITLE
fix(slick-grid): changed array destructuring to object destructuring for bug fix [SO-2944592]

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -461,7 +461,7 @@
     }
 
     function expandCollapseGroup(args, collapse) {
-      const [level, groupingKey] = resolveLevelAndGroupingKey(args);
+      const {level, groupingKey} = resolveLevelAndGroupingKey(args);
       toggledGroupsByLevel[level][groupingKey] = groupingInfos[level].collapsed ^ collapse;
       refresh();
 


### PR DESCRIPTION
What feature or fix was requested?

In slick grid toggle function was not working, it was giving an error so instead of array destructing object destructing was required.

Is there any specific condition to reproduce the scenario?

You need to have Pac Medico Profile.
Go to Clinical Panoroma function, select the filters, go to patient list tab, click on the toggle.

Which functions have you tested your implementation?
Clinical Panoroma -> Patient List