### PR TITLE
fix(slick-grid):solving setAttribute js problem that takes a customAttr string as value [SO-2937651]

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2730,17 +2730,26 @@
           ${attr}
         >`;
 
-      const rowElemt = document.createElement("div");
+      let rowElemt = document.createElement('div');
+      if (attr && attr.length) {
+        
+        const htmlToElem = (html) => {
+          const temp = document.createElement('template');
+          temp.innerHTML = html.trim();
+          return temp.content.firstChild;
+        };
+        
+        rowElemt = htmlToElem(`<div ${attr}>`);
+      }
+
       if (options.draggable) {
         rowElemt.setAttribute('draggable','true')
         rowElemt.setAttribute('data-draggable-row');
       }
+
       rowElemt.setAttribute('class', `ui-widget-content ${rowCss}`);
       rowElemt.setAttribute('data-row-idx', `${row}`);
       rowElemt.setAttribute('style', `top: ${getRowTop(row) - frozenRowOffset}px; height: ${getRowHeight(row)}px;`);
-      if (attr && attr.length) {
-        rowElemt.setAttribute(`${attr}`);
-      }
 
       if (hasFrozenColumns()) {
         stringArrayR.push(rowHtml);


### PR DESCRIPTION
Solving setAttribute js problem that takes a customAttr string as value :

![image](https://user-images.githubusercontent.com/77120548/182376938-e3686417-e391-4ee7-b6a4-bff1ed21b1b1.png)
![image](https://user-images.githubusercontent.com/77120548/182376975-47bed67c-2159-4ff6-b4bd-796eeeb5cce6.png)
